### PR TITLE
Use browser APIs instead of bundled character entity list in browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
 language: node_js
 node_js:
-- lts/boron
-- node
+  - lts/boron
+  - node
+addons:
+  apt:
+    packages:
+      - xvfb
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - npm install
+script:
+  - npm test
+  - npm run test-browser -- --browser=firefox
 after_script: bash <(curl -s https://codecov.io/bash)
 deploy:
   provider: releases

--- a/decode-entity.browser.js
+++ b/decode-entity.browser.js
@@ -4,10 +4,13 @@ var el
 module.exports = decodeEntity
 
 function decodeEntity(characters) {
+  var char
+  var entity
+
   el = el || document.createElement('em')
-  var entity = '&' + characters + ';'
+  entity = '&' + characters + ';'
   el.innerHTML = entity
-  var char = el.textContent
+  char = el.textContent
 
   // Some entities do not require the closing semicolon (&not - for instance),
   // which leads to situations where parsing the assumed entity of &notit; will

--- a/decode-entity.browser.js
+++ b/decode-entity.browser.js
@@ -1,0 +1,23 @@
+/* eslint-env browser */
+var el
+
+module.exports = decodeEntity
+
+function decodeEntity(characters) {
+  el = el || document.createElement('em')
+  var entity = '&' + characters + ';'
+  el.innerHTML = entity
+  var char = el.textContent
+
+  // Some entities do not require the closing semicolon (&not - for instance),
+  // which leads to situations where parsing the assumed entity of &notit; will
+  // result in the string "¬it;". When we encounter a trailing semicolon after
+  // parsing and the entity to decode was not a semicolon (&semi;), we can
+  // assume that the matching was incomplete
+  if (char.slice(-1) === ';' && characters !== 'semi') {
+    return false
+  }
+
+  // If the decoded string is equal to the input, the entity was not valid
+  return char === entity ? false : char
+}

--- a/decode-entity.js
+++ b/decode-entity.js
@@ -1,0 +1,11 @@
+const characterEntities = require('character-entities')
+
+module.exports = decodeEntity
+
+var own = {}.hasOwnProperty
+
+function decodeEntity(characters) {
+  return (
+    own.call(characterEntities, characters) && characterEntities[characters]
+  )
+}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var characterEntities = require('character-entities')
 var legacy = require('character-entities-legacy')
 var invalid = require('character-reference-invalid')
 var decimal = require('is-decimal')
 var hexadecimal = require('is-hexadecimal')
 var alphanumerical = require('is-alphanumerical')
+var decodeEntity = require('./decode-entity')
 
 module.exports = parseEntities
 
@@ -246,9 +246,10 @@ function parse(value, settings) {
       if (terminated) {
         end++
 
-        if (type === NAMED && own.call(characterEntities, characters)) {
+        var namedEntity = type === NAMED && decodeEntity(characters)
+        if (namedEntity) {
           entityCharacters = characters
-          entity = characterEntities[characters]
+          entity = namedEntity
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ function parse(value, settings) {
   var queue = ''
   var result = []
   var entityCharacters
+  var namedEntity
   var terminated
   var characters
   var character
@@ -246,7 +247,7 @@ function parse(value, settings) {
       if (terminated) {
         end++
 
-        var namedEntity = type === NAMED && decodeEntity(characters)
+        namedEntity = type === NAMED && decodeEntity(characters)
         if (namedEntity) {
           entityCharacters = characters
           entity = namedEntity

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "remark-cli": "^5.0.0",
     "remark-preset-wooorm": "^4.0.0",
     "tape": "^4.2.0",
+    "tape-run": "^4.0.0",
     "xo": "^0.20.0"
   },
   "scripts": {
@@ -48,7 +49,8 @@
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test.js",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-browser": "browserify test.js | tape-run",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-browser"
   },
   "nyc": {
     "check-coverage": true,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)"
   ],
+  "browser": {
+    "./decode-entity.js": "./decode-entity.browser.js"
+  },
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
I briefly discussed this with you (@wooorm) on [Gitter](https://gitter.im/remarkjs/Lobby?at=5b9c2c17fcba1254fab859a2) - that the main bulk of remark-parse (in byte size) stems from this library including `character-entities` as a dependency.

You had a brilliant and simple solution in that one could actually just use `innerHTML` + `textContent` to decode entities in the browser. 

This is a first stab at the problem. Tests seem to pass (do you have a preferred way of testing on CI in browsers?) both in node and browser, and the size decrease is already quite significant:

```sh
~/webdev/parse-entities [master] $ browserify index.js | bundle-collapser | uglifyjs -c -m | wc -c
    34797

~/webdev/parse-entities [master] $ git checkout slim-browser
Switched to branch 'slim-browser'

~/webdev/parse-entities [slim-browser] $ browserify index.js | bundle-collapser | uglifyjs -c -m | wc -c
    5282
```

Feel free to change any part of this you don't like - code style or implementation-wise, obviously.