### PR TITLE
Support React Native, use the normal decode-entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "browser": {
     "./decode-entity.js": "./decode-entity.browser.js"
   },
+  "react-native": {
+    "./decode-entity.js": "./decode-entity.js"
+  },
   "files": [
     "index.js",
     "decode-entity.js",


### PR DESCRIPTION
`react-markdown` (which supports React Native nowadays) requires `remark-parse` which requires `parse-entities`, and the React Native bundler seems to pick up (for some reason) the replacement field `"browser"` in package.json, which throws an error because `decode-entity.browser.js` uses `document`, and that's not present in React Native.

This PR adds the replacement field `"react-native"` in package.json, which in the React Native bundler takes priority over `"browser"`, to use the default `decode-entity.js` file. I tested this solution in an actual RN app and it works.